### PR TITLE
Fix missing M in params number

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@
         <b>low</b> - 16Khz audio, 15-20M params
       </li>
       <li>
-        <b>medium</b> - 22.05Khz audio, 15-20 params
+        <b>medium</b> - 22.05Khz audio, 15-20M params
       </li>
       <li>
         <b>high</b> - 22.05Khz audio, 28-32M params


### PR DESCRIPTION
I believe there is a missing 'M' next to the number of parameters in the medium quality level. It currently reads "medium - 22.05Khz audio, 15-20 params", but I think it should be "medium - 22.05Khz audio, 15-20M params".